### PR TITLE
Improve Blender 4 4 compatibility

### DIFF
--- a/blender-tools/vpipeline_addon.py
+++ b/blender-tools/vpipeline_addon.py
@@ -2,10 +2,11 @@ bl_info = {
     "name": "V Pipeline",
     "description": "Vertex based pipeline",
     "author": "Michael Jared",
-    "version": (0,1),
-    "location": "View3D > Properties > Godot Pipeline",
+    "version": (0, 2),
+    "location": "View3D > Properties > V Pipeline",
     "doc_url": "https://www.michaeljared.ca",
-    "blender": (2, 80, 0),
+    "tracker_url": "https://github.com/bikemurt/VertexPipeline/issues",
+    "blender": (4, 4, 0),
     "category": "Generic"
 }
 

--- a/blender-tools/vpipeline_addon.py
+++ b/blender-tools/vpipeline_addon.py
@@ -13,21 +13,22 @@ bl_info = {
 import bpy, math
 from mathutils import Vector, Color
 from bpy.types import (
-            Operator,
-            PropertyGroup, 
-            Panel,
-            UIList,
-            Object
-        )
+    Object,
+    Operator,
+    Panel,
+    PropertyGroup,
+    Scene,
+    UIList
+)
 from bpy.props import (
-            IntProperty,
-            EnumProperty,
-            BoolProperty,
-            FloatProperty,
-            StringProperty,
-            PointerProperty,
-            CollectionProperty
-        )
+    IntProperty,
+    EnumProperty,
+    BoolProperty,
+    FloatProperty,
+    StringProperty,
+    PointerProperty,
+    CollectionProperty
+)
     
 ### PROPS
 
@@ -45,7 +46,7 @@ class VPipelineProperties(PropertyGroup):
 
 ### PANEL
 
-class VPipelinePanel(bpy.types.Panel):
+class VPipelinePanel(Panel):
     bl_idname = "OBJECT_PT_v_pipeline"
     bl_label = "V Pipeline"
     bl_space_type = 'VIEW_3D'
@@ -219,7 +220,7 @@ def color_match(col1, col2, tol=0.001):
 
 ### OPERATORS
 
-class SetActive(bpy.types.Operator):
+class SetActive(Operator):
     """Set Active"""
     bl_idname = "object.v_set_active"
     bl_label = "Set Active"
@@ -263,7 +264,7 @@ class SetActive(bpy.types.Operator):
         
         return {'FINISHED'}
 
-class SetMetalColor(bpy.types.Operator):
+class SetMetalColor(Operator):
     """Set Metal Color"""
     bl_idname = "object.v_set_metal_color"
     bl_label = "Set Metal Color"
@@ -290,7 +291,7 @@ class SetMetalColor(bpy.types.Operator):
             
         return {'FINISHED'}
 
-class SelectCurrentColor(bpy.types.Operator):
+class SelectCurrentColor(Operator):
     """Select Current Color"""
     bl_idname = "object.v_select_current_color"
     bl_label = "Select Current Color"
@@ -337,7 +338,7 @@ class SelectCurrentColor(bpy.types.Operator):
         return {'FINISHED'}
 
 
-class PrintPalette(bpy.types.Operator):
+class PrintPalette(Operator):
     """Print Palette"""
     bl_idname = "object.v_print_palette"
     bl_label = "Print Palette"
@@ -394,7 +395,7 @@ class PrintPalette(bpy.types.Operator):
             
         return {'FINISHED'}
 
-class Setup(bpy.types.Operator):
+class Setup(Operator):
     """Setup"""
     bl_idname = "object.v_setup"
     bl_label = "Setup"
@@ -477,7 +478,7 @@ class Setup(bpy.types.Operator):
             
         return {'FINISHED'}
 
-class VPaint(bpy.types.Operator):
+class VPaint(Operator):
     """V Paint"""
     bl_idname = "object.v_paint"
     bl_label = "V Paint"
@@ -501,7 +502,7 @@ class VPaint(bpy.types.Operator):
 
 
 
-class MapUVs(bpy.types.Operator):
+class MapUVs(Operator):
     """Map UVs"""
     bl_idname = "object.v_map_uvs"
     bl_label = "Map UVs"
@@ -568,7 +569,7 @@ class MapUVs(bpy.types.Operator):
         return {'FINISHED'}
 
 
-class PrepExport(bpy.types.Operator):
+class PrepExport(Operator):
     """Prep for Export"""
     bl_idname = "object.v_prep_export"
     bl_label = "Prep for Export"
@@ -625,7 +626,7 @@ def register():
     for cls in classes:
         bpy.utils.register_class(cls)
     
-    bpy.types.Scene.VPipelineProps = PointerProperty(type = VPipelineProperties)
+    Scene.VPipelineProps = PointerProperty(type = VPipelineProperties)
 
 def unregister():
     for cls in classes:

--- a/blender-tools/vpipeline_addon.py
+++ b/blender-tools/vpipeline_addon.py
@@ -32,10 +32,7 @@ from bpy.props import (
     
 ### PROPS
 
-class VPipelineProperties(PropertyGroup):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-    
+class VPipelineProperties(PropertyGroup):   
     color_name : StringProperty(name = "Color Vertex Data", default = "ColorX", description = "Color Vertex Data")
     metal_name : StringProperty(name = "Metal/Rough Vertex Data", default = "MetalX", description = "Color Vertex Data")
     v_name : StringProperty(name = "V Name", default = "", description = "Current Vertex Data Name")
@@ -55,9 +52,6 @@ class VPipelinePanel(Panel):
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'UI'
     bl_category = "V Pipeline"
-    
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
     
     @classmethod
     def poll(cls, context):
@@ -200,8 +194,7 @@ class VPipelinePanel(Panel):
         else:
             row = layout.row()
             row.label(text="Setup incomplete.")
-        
-        
+
 ### HELPER FUNCTIONS
 
 def srgb_to_linear(c):
@@ -233,9 +226,6 @@ class SetActive(Operator):
     bl_options = {'REGISTER', 'UNDO'}
     
     active_name: IntProperty(name = "Set Active Name", default=0)
-    
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
     
     @classmethod
     def poll(cls, context):
@@ -281,9 +271,6 @@ class SetMetalColor(Operator):
     
     palette_index: IntProperty(name = "Palette Index", default=0)
     
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-    
     @classmethod
     def poll(cls, context):
         # Make the operator available in all contexts by returning True
@@ -310,9 +297,6 @@ class SelectCurrentColor(Operator):
     bl_options = {'REGISTER', 'UNDO'}
     
     index: IntProperty(name = "Index", default=0)
-    
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
     
     @classmethod
     def poll(cls, context):
@@ -352,15 +336,11 @@ class SelectCurrentColor(Operator):
         
         return {'FINISHED'}
 
-
 class PrintPalette(Operator):
     """Print Palette"""
     bl_idname = "object.v_print_palette"
     bl_label = "Print Palette"
     bl_options = {'REGISTER', 'UNDO'}
-    
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
     
     @classmethod
     def poll(cls, context):
@@ -418,9 +398,6 @@ class Setup(Operator):
     bl_idname = "object.v_setup"
     bl_label = "Setup"
     bl_options = {'REGISTER', 'UNDO'}
-    
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
     
     @classmethod
     def poll(cls, context):
@@ -505,9 +482,6 @@ class VPaint(Operator):
     bl_label = "V Paint"
     bl_options = {'REGISTER', 'UNDO'}
     
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-    
     @classmethod
     def poll(cls, context):
         # Make the operator available in all contexts by returning True
@@ -524,8 +498,6 @@ class VPaint(Operator):
         
         return {'FINISHED'}
 
-
-
 class MapUVs(Operator):
     """Map UVs"""
     bl_idname = "object.v_map_uvs"
@@ -533,9 +505,6 @@ class MapUVs(Operator):
     bl_options = {'REGISTER', 'UNDO'}
     
     map: BoolProperty(name = "Map", default=True)
-    
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
     
     @classmethod
     def poll(cls, context):
@@ -595,7 +564,6 @@ class MapUVs(Operator):
                     
         return {'FINISHED'}
 
-
 class PrepExport(Operator):
     """Prep for Export"""
     bl_idname = "object.v_prep_export"
@@ -603,9 +571,6 @@ class PrepExport(Operator):
     bl_options = {'REGISTER', 'UNDO'}
     
     reset: BoolProperty(name = "Reset", default=False)
-    
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
     
     @classmethod
     def poll(cls, context):
@@ -645,7 +610,6 @@ class PrepExport(Operator):
                 obj.data.materials.clear()
         
         return {'FINISHED'}
-
 
 ###
 

--- a/blender-tools/vpipeline_addon.py
+++ b/blender-tools/vpipeline_addon.py
@@ -33,6 +33,9 @@ from bpy.props import (
 ### PROPS
 
 class VPipelineProperties(PropertyGroup):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+    
     color_name : StringProperty(name = "Color Vertex Data", default = "ColorX", description = "Color Vertex Data")
     metal_name : StringProperty(name = "Metal/Rough Vertex Data", default = "MetalX", description = "Color Vertex Data")
     v_name : StringProperty(name = "V Name", default = "", description = "Current Vertex Data Name")
@@ -52,6 +55,9 @@ class VPipelinePanel(Panel):
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'UI'
     bl_category = "V Pipeline"
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
     
     @classmethod
     def poll(cls, context):
@@ -228,6 +234,9 @@ class SetActive(Operator):
     
     active_name: IntProperty(name = "Set Active Name", default=0)
     
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+    
     @classmethod
     def poll(cls, context):
         # Make the operator available in all contexts by returning True
@@ -272,6 +281,9 @@ class SetMetalColor(Operator):
     
     palette_index: IntProperty(name = "Palette Index", default=0)
     
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+    
     @classmethod
     def poll(cls, context):
         # Make the operator available in all contexts by returning True
@@ -298,6 +310,9 @@ class SelectCurrentColor(Operator):
     bl_options = {'REGISTER', 'UNDO'}
     
     index: IntProperty(name = "Index", default=0)
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
     
     @classmethod
     def poll(cls, context):
@@ -343,6 +358,9 @@ class PrintPalette(Operator):
     bl_idname = "object.v_print_palette"
     bl_label = "Print Palette"
     bl_options = {'REGISTER', 'UNDO'}
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
     
     @classmethod
     def poll(cls, context):
@@ -400,6 +418,9 @@ class Setup(Operator):
     bl_idname = "object.v_setup"
     bl_label = "Setup"
     bl_options = {'REGISTER', 'UNDO'}
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
     
     @classmethod
     def poll(cls, context):
@@ -484,6 +505,9 @@ class VPaint(Operator):
     bl_label = "V Paint"
     bl_options = {'REGISTER', 'UNDO'}
     
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+    
     @classmethod
     def poll(cls, context):
         # Make the operator available in all contexts by returning True
@@ -509,6 +533,9 @@ class MapUVs(Operator):
     bl_options = {'REGISTER', 'UNDO'}
     
     map: BoolProperty(name = "Map", default=True)
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
     
     @classmethod
     def poll(cls, context):
@@ -576,6 +603,9 @@ class PrepExport(Operator):
     bl_options = {'REGISTER', 'UNDO'}
     
     reset: BoolProperty(name = "Reset", default=False)
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
     
     @classmethod
     def poll(cls, context):

--- a/blender-tools/vpipeline_addon.py
+++ b/blender-tools/vpipeline_addon.py
@@ -32,7 +32,7 @@ from bpy.props import (
     
 ### PROPS
 
-class VPipelineProperties(PropertyGroup):   
+class VPipelineProperties(PropertyGroup):
     color_name : StringProperty(name = "Color Vertex Data", default = "ColorX", description = "Color Vertex Data")
     metal_name : StringProperty(name = "Metal/Rough Vertex Data", default = "MetalX", description = "Color Vertex Data")
     v_name : StringProperty(name = "V Name", default = "", description = "Current Vertex Data Name")

--- a/blender-tools/vpipeline_addon.py
+++ b/blender-tools/vpipeline_addon.py
@@ -162,7 +162,7 @@ class VPipelinePanel(Panel):
                     index = 0
                 elif props.active_palette == props.metal_name:
                     s = "Metal"
-                    index = 0
+                    index = 1
                 
                 if s != "":
                     row = box.row()

--- a/blender-tools/vpipeline_addon.py
+++ b/blender-tools/vpipeline_addon.py
@@ -139,7 +139,7 @@ class VPipelinePanel(Panel):
                 row.operator("object.v_set_active", icon='NONE', text="Metal").active_name = 1
                 
                 row = box.row()
-                row.operator("object.v_paint", text="Paint Vertex Colors", icon="BRUSH_PAINT_SELECT")
+                row.operator("object.v_paint", text="Paint Vertex Colors", icon="VPAINT_HLT")
                 
                 row = box.row()
                 row.prop(context.tool_settings.vertex_paint.brush, "color", text="Active Color")


### PR DESCRIPTION
This PR attempts to fix the Blender addon so that it works with Blender 4.4.

- The `bl_info` definition was cleaned up, with the `blender` property bumped to indicate Blender 4.4 support. `tracker_url` pointing to this repository's issues has also been added.
- The icon "BRUSH_PAINT_SELECT" seem to have been removed wither in 4.3 or 4.4 and this was causing the UI to not be created properly. It was replaced with "VPAINT_HLT" since I could not find the previous icon anymore.
- I am not quite sure what the `object.v_select_current_color` operator is supposed to do, but when invoking it from the panel we were always passing 0 as the `index`. When reading the operator's code, there is a check on whether `index` is 0 or 1 to know if we're in color mode or metal mode, so I figured this might have been a bug and fixed it to pass the correct index. (Let me know if this makes sense, I am really not sure about this one)
- Some minor formating was applied like removing whitespace and removing redundant `bpy.types.` specifications.

I came across a few other bugs, but this PR should at least makes the addon function with Blender 4.4 🙂